### PR TITLE
Adapt to renamed file upload config keys

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -38,14 +38,14 @@ spring:
     mvc:
         favicon:
             enabled: false
+    http:
+        multipart:
+            max-file-size: 1024MB
+            max-request-size: 1024MB
 
 security:
     basic:
         enabled: false
-
-multipart:
-    maxFileSize: 1024MB
-    maxRequestSize: 1024MB
 
 # ===================================================================
 # JHipster specific properties


### PR DESCRIPTION
It appears the relevant config item keys were changed in a recent Spring (or Spring Boot) upgrade. Fixed in this PR. Is 1GB a reasonable default?