### PR TITLE
Feature replay url

### DIFF
--- a/src/main/java/org/powertac/visualizer/service_ptac/EmbeddedService.java
+++ b/src/main/java/org/powertac/visualizer/service_ptac/EmbeddedService.java
@@ -1,6 +1,8 @@
 package org.powertac.visualizer.service_ptac;
 
 import org.apache.commons.io.FileExistsException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.powertac.common.interfaces.VisualizerProxy;
 import org.powertac.visualizer.config.Constants;
 import org.powertac.server.CompetitionControlService;
@@ -17,6 +19,8 @@ import org.powertac.visualizer.service_ptac.VisualizerService.VisualizerState;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.InputStream;
+
 import javax.annotation.PostConstruct;
 
 /**
@@ -26,6 +30,8 @@ import javax.annotation.PostConstruct;
  */
 @Service
 public class EmbeddedService {
+
+    Logger log = LogManager.getLogger(EmbeddedService.class);
 
     @Autowired
     private FileService fileService;
@@ -162,7 +168,7 @@ public class EmbeddedService {
      * @see org.powertac.visualizer.service.ptac.VisualizerCompetitionServiceIf#
      * runReplayGame(org.powertac.visualizer.domain.Game)
      */
-    public String runReplayGame(File file) {
+    public String runReplayGame(InputStream source) {
         String error = checkRun();
         if (error != null) {
             return error;
@@ -176,7 +182,10 @@ public class EmbeddedService {
                 // No SimStart and SimEnd when extracting log
                 visualizerService.setState(VisualizerState.RUNNING);
                 LogtoolExecutor logtoolExecutor = new LogtoolExecutor();
-                logtoolExecutor.readLog(file.getPath(), messageDispatcher);
+                String error = logtoolExecutor.readLog(source, messageDispatcher);
+                if (error != null) {
+                  log.error("Error during replay: " + error);
+                }
                 replayGameThread = null;
                 visualizerService.setState(VisualizerState.FINISHED);
             }

--- a/src/main/java/org/powertac/visualizer/web/rest/FileResource.java
+++ b/src/main/java/org/powertac/visualizer/web/rest/FileResource.java
@@ -263,11 +263,18 @@ public class FileResource {
           }
         }
         try (
-            OutputStream out = new BufferedOutputStream(new FileOutputStream(raw))
+            OutputStream out = new FileOutputStream(raw);
+            InputStream in = part.getInputStream()
         ) {
-            byte[] bytes = part.getBytes();
-            out.write(bytes);
-            out.close();
+            byte[] buf = new byte[65536];
+            while (true) {
+              int len = in.read(buf);
+              if (len > 0) {
+                out.write(buf, 0, len);
+              } else {
+                break;
+              }
+            }
 
             File file = new File();
             file.setType(fileType);

--- a/src/main/java/org/powertac/visualizer/web/rest/errors/ErrorConstants.java
+++ b/src/main/java/org/powertac/visualizer/web/rest/errors/ErrorConstants.java
@@ -8,6 +8,8 @@ public final class ErrorConstants {
     public static final String ERR_METHOD_NOT_SUPPORTED = "error.methodNotSupported";
     public static final String ERR_ILLEGAL_ARGUMENT = "error.illegalArgument";
     public static final String ERR_FILE_NOT_FOUND = "error.fileNotFound";
+    public static final String ERR_IOEXCEPTION = "error.ioException";
+    public static final String ERR_MALFORMED_URL_EXCEPTION = "error.malformedUrl";
     public static final String ERR_FILE_EXISTS = "error.fileExists";
     public static final String ERR_FILE_TOO_LARGE = "error.fileTooLarge";
     public static final String ERR_FORBIDDEN = "error.forbidden";

--- a/src/main/java/org/powertac/visualizer/web/rest/errors/ExceptionTranslator.java
+++ b/src/main/java/org/powertac/visualizer/web/rest/errors/ExceptionTranslator.java
@@ -1,6 +1,8 @@
 package org.powertac.visualizer.web.rest.errors;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
 import java.util.List;
 
 import org.apache.commons.io.FileExistsException;
@@ -76,6 +78,20 @@ public class ExceptionTranslator {
     @ResponseBody
     public ErrorVM processFileNotFoundException(FileNotFoundException e) {
         return new ErrorVM(ErrorConstants.ERR_FILE_NOT_FOUND, e.getMessage());
+    }
+
+    @ExceptionHandler(IOException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    public ErrorVM processIOException(IOException e) {
+        return new ErrorVM(ErrorConstants.ERR_IOEXCEPTION, e.getMessage());
+    }
+
+    @ExceptionHandler(MalformedURLException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorVM processMalformedURLException(MalformedURLException e) {
+        return new ErrorVM(ErrorConstants.ERR_MALFORMED_URL_EXCEPTION, e.getMessage());
     }
 
     @ExceptionHandler(FileExistsException.class)

--- a/src/main/webapp/app/games/games.controller.js
+++ b/src/main/webapp/app/games/games.controller.js
@@ -16,6 +16,8 @@
     vm.removeBroker = removeBroker;
     vm.getFile = getFile;
     vm.clearFile = clearFile;
+    vm.setSource = setSource;
+    vm.setReplayUrl = setReplayUrl;
     vm.start = start;
     vm.stop = stop;
     vm.isStartButtonDisabled = isStartButtonDisabled;
@@ -33,7 +35,7 @@
       vm.brokers = {};
       vm.brokerCollection = [];
       vm.games = [];
-      vm.replayGame = null;
+      setSource(null);
 
       Games.reset();
     }
@@ -73,6 +75,22 @@
       return Games[type + 'File'] = null;
     }
 
+    function setSource (source) {
+      vm.replaySource = source;
+      vm.replayUrl = '';
+      vm.replayUrlTemp = '';
+      vm.replayGame = null;
+    }
+
+    function setReplayUrl (url) {
+      if (url === undefined) {
+        vm.replayUrl = vm.replayUrlTemp;
+      } else {
+        vm.replayUrl = vm.replayUrlTemp = url;
+      }
+      console.log('set', url, vm.replayUrl);
+    }
+
     function start () {
       if (vm.mode === 'BOOT') {
         startBoot();
@@ -110,7 +128,7 @@
         return true;
       } else if (vm.mode === 'BOOT' && vm.gameName) {
         return true;
-      } else if (vm.mode === 'REPLAY' && Games.stateFile) {
+      } else if (vm.mode === 'REPLAY' && vm.replaySource && (Games.stateFile || vm.replayUrl)) {
         return true;
       }
       return false;
@@ -163,20 +181,32 @@
     }
 
     function startReplay () {
-      Games.replay (Games.stateFile,
-        function() {
-          setMode('');
-        },
-        function (error) {
-          console.error('Failed replay', error);
-        }
-      );
+      if  (vm.replaySource === 'EXTERNAL') {
+        Games.replayExternal(vm.replayUrl,
+            function () {
+              setMode('');
+            },
+            function (error) {
+              console.error('Failed replay', error);
+            }
+        );
+      } else {
+        Games.replayInternal(Games.stateFile,
+            function () {
+              setMode('');
+            },
+            function (error) {
+              console.error('Failed replay', error);
+            }
+        );
+      }
     }
 
     function stopGame () {
       Games.close(
           function() {
             setMode('');
+            setSource('');
           },
           function (error) {
             console.error('Failed stop', error);

--- a/src/main/webapp/app/games/games.html
+++ b/src/main/webapp/app/games/games.html
@@ -245,6 +245,26 @@
           <div ng-show="vm.mode === 'REPLAY'">
             <br />
             <div class="form-group">
+              <label class="col-md-3">Select the source for game replay:</label>
+
+              <div class="col-md-9">
+                <div class="radio radio-primary">
+                  <label>
+                    <input type="radio" ng-click="vm.setSource('INTERNAL')" ng-checked="vm.replaySource === 'INTERNAL'" />
+                    I want to select an internal state file.
+                  </label>
+                </div>
+                <div class="radio radio-primary">
+                  <label>
+                    <input type="radio" ng-click="vm.setSource('EXTERNAL')" ng-checked="vm.replaySource === 'EXTERNAL'" />
+                    I want to provide an URL to an external state file (archive).
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group" ng-show="vm.replaySource === 'INTERNAL'">
+              <br />
               <label class="col-md-3" for="stateFileInput">
                 Your state file (required):
               </label>
@@ -268,6 +288,37 @@
                     </button>
                   </span>
                 </span>
+              </div>
+            </div>
+
+            <div class="form-group" ng-show="vm.replaySource === 'EXTERNAL'">
+              <br />
+              <label class="col-md-3" for="replayUrlInput">
+                The URL to your state file (required):
+              </label>
+              <div class="col-md-9">
+                <div class="form-inline">
+                  <input class="form-control" id="replayUrlInput" ng-model="vm.replayUrlTemp"
+                         placeholder="Enter URL of state file (archive) ..." style="width:80%"
+                         ng-keyup="$event.keyCode === 13 && vm.setReplayUrl(vm.replayUrlTemp)"
+                         ng-blur="vm.setReplayUrl(vm.replayUrlTemp)" />
+                  <span ng-switch="vm.replayUrl.length > 0">
+                    <span ng-switch-when="false">
+                      <button type="button" class="btn btn-default" ng-disabled="!vm.replayUrlTemp"
+                              ng-click="vm.setReplayUrl()">
+                        <span class="glyphicon glyphicon-ok-circle"></span>
+                        <span class="hidden-sm">Set</span>
+                      </button>
+                    </span>
+                    <span ng-switch-when="true">
+                      <button type="button" class="btn btn-default"
+                              ng-click="vm.setReplayUrl('')">
+                        <span class="glyphicon glyphicon-remove-circle"></span>
+                        <span class="hidden-sm">Clear</span>
+                      </button>
+                    </span>
+                 </span>
+                </div>
               </div>
             </div>
           </div>

--- a/src/main/webapp/app/games/games.service.js
+++ b/src/main/webapp/app/games/games.service.js
@@ -12,7 +12,8 @@
       list: list,
       boot: boot,
       run: run,
-      replay: replay,
+      replayInternal: replayInternal,
+      replayExternal: replayExternal,
       close: close,
       reset: reset
     };
@@ -41,9 +42,15 @@
       $http.post('api/simgame?overwrite=' + overwrite, game).then(success, error);
     }
 
-    function replay (file, success, error) {
-      console.log('Starting replay');
-      $http.post('api/replaygame', file).then(success, error);
+    function replayInternal (file, success, error) {
+      console.log('Starting replay internal');
+      $http.post('api/replaygame_internal', file).then(success, error);
+    }
+
+
+    function replayExternal (file, success, error) {
+      console.log('Starting replay external');
+      $http.post('api/replaygame_external', file).then(success, error);
     }
 
     function close (success, error) {


### PR DESCRIPTION
I've added the option to replay an external state file by pasting an URL into a textbox in the visualizer GUI. It can point to a regular state file, optionally supports decompression and untarring (autodetected from the stream).

No need to clean up afterwards because I'm piping the stream straight into logtool-core and never write anything to disk (well, nothing of state anyway).

Note: this depends on another PR in logtool-core: https://github.com/powertac/logtool-core/pull/7